### PR TITLE
Gt-59: Switched from os.Args to flag

### DIFF
--- a/main/init/bootstrap/init.sh
+++ b/main/init/bootstrap/init.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-bPort=6000
+bPort="-port 6000"
 go run /go/src/D7024E/main/main.go $bPort

--- a/main/init/node/init.sh
+++ b/main/init/node/init.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 #$rval = shuf -i 6001-9999 -n 1
-bstrap="10.0.0.2:6000"
-go run /go/src/D7024E/main/main.go $1 $bstrap
+port="-port"
+bstrap="-bootstrapIP 10.0.0.2:6000"
+go run /go/src/D7024E/main/main.go $port $1 $bstrap

--- a/main/main.go
+++ b/main/main.go
@@ -3,13 +3,8 @@ package main
 //powershell.exe -executionpolicy bypass .\run.ps1
 import (
 	d "D7024E"
-	"fmt"
-	"log"
-	"net"
-	"os"
+	"flag"
 	"runtime"
-	"strconv"
-	"strings"
 	"sync"
 )
 
@@ -17,111 +12,20 @@ var wg sync.WaitGroup
 
 func main() {
 	runtime.GOMAXPROCS(1)
-	//Read port from args
-	myport := "1"
-	if len(os.Args) > 1 {
-		myport = os.Args[1]
+	myport := flag.String("port", "7070", "Provide any port, if unset defaluts to 7070")
+	bootstrap := flag.String("bootstrapIP", "", "Provide the ip of any node to join network, if unset this node is asumed to be bootstrap")
+	flag.Parse()
+	var newNode *d.Network
+
+	if *bootstrap != "" {
+		newNode = d.InitJoin(*myport, *bootstrap)
+	} else {
+		newNode = d.InitBootstrap(*myport)
 	}
-	iPort, err := strconv.Atoi(myport)
-	ErrorHandler(err)
-	myip, err := externalIP()
-	ErrorHandler(err)
-	if myip == "" {
-		myip = "127.0.0.1"
-	}
-	me := d.NewContact(d.NewRandomKademliaID(), myip+":"+myport)
-	fmt.Println("I am: ", me.ID, me.Address+"\n")
 
-	newNode := d.InitNode(myip, iPort, &me)
-	//Read ip & node from args (node to join)
-	bIP := ""
-	//bNode := ""
-	//Check if a known bootstrap node (c) was given
-	if len(os.Args[1:]) == 2 {
-		bIP = os.Args[2]
-		//bNode = os.Args[3] we dont need to know nodeID only ip:port
-		if bIP != "" {
-			//Make contact of bootstrap node.
-			bContact := d.NewContact(nil, bIP)
-
-			//RPC PING node c and update buckets
-			newNode.SendPingMessage(&bContact)
-
-			/*Check if my bucket was updated
-			myContacts := newNode.Kad.Rtable.FindClosestContacts(d.NewKademliaID("0000000000000000000000000000000000000000"), 160)
-			if len(myContacts) == 0 {
-				ErrorHandler(errors.New("pinging bootstrap failed or buckets weren't updated"))
-			}
-			*/
-			//iterativeFindNode for new node n
-			val := newNode.IterativeFindNode()
-			for _, c := range val {
-				newNode.Kad.Rtable.AddContact(c)
-			}
-
-			//Update the k-buckets further away than the one bootstrap node falls in
-			/*
-				for i := 160; i > newNode.Kad.Rtable.GetBucketIndex(findBootstrap[0].ID); i-- {
-					for k := 20; k < 20; k++ {
-						newNode.SendPingMessage(&findBootstrap[i])
-
-					}
-				}*/
-		}
-
-	}
-	//out := make(chan []d.Contact)
-	//
 	wg.Add(2)
-	go newNode.Listen(me, iPort)
+	go newNode.Listen(*newNode.Contact)
 	go newNode.Cli()
 	wg.Wait()
 
-}
-
-//ErrorHandler to not fill code with if statements
-func ErrorHandler(err error) {
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-func externalIP() (string, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return "", err
-	}
-	for _, iface := range ifaces {
-		if iface.Flags&net.FlagUp == 0 {
-			continue // interface down
-		}
-		if iface.Flags&net.FlagLoopback != 0 {
-			continue // loopback interface
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return "", err
-		}
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-			if ip == nil || ip.IsLoopback() {
-				continue
-			}
-			ip = ip.To4()
-			if ip == nil {
-				continue // not an ipv4 address
-			}
-			if strings.Index(ip.String(), "10.") == 0 { //IP should start at 10. within containers
-				return ip.String(), nil
-			}
-
-		}
-	}
-	return "", err
 }

--- a/main/run.ps1
+++ b/main/run.ps1
@@ -1,12 +1,12 @@
 ﻿$file = "$pwd\main.exe" 
-$bootstrap = "localhost:1"
+$bootstrap = "-bootstrapIP localhost:1"
 go build .\main.go
 Start-Sleep -Seconds 2
-Start-Process powershell.exe -ArgumentList $file, "1"
+Start-Process powershell.exe -ArgumentList $file, "-port 1"
 Start-Sleep -Milliseconds 1000
 For ($i=2; $i -le 30; $i++) {
-Start-Process -NoNewWindow powershell.exe -ArgumentList $file, $i, $bootstrap
+Start-Process -NoNewWindow powershell.exe -ArgumentList $file, "-port $i", $bootstrap
 Start-Sleep -Milliseconds 500
 }
 Start-Sleep -Milliseconds 500
-Start-Process powershell.exe -ArgumentList $file, "40", $bootstrap
+Start-Process powershell.exe -ArgumentList $file, "-port 40", $bootstrap

--- a/util.go
+++ b/util.go
@@ -1,6 +1,51 @@
 package D7024E
 
-import "strings"
+import (
+	"net"
+	"strings"
+)
+
+func Eth0IP() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue // interface down
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue // loopback interface
+		}
+		if iface.Name == "eth0" {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				return "", err
+			}
+			for _, addr := range addrs {
+				var ip net.IP
+				switch v := addr.(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+				if ip == nil || ip.IsLoopback() {
+					continue
+				}
+				ip = ip.To4()
+				if ip == nil {
+					continue // not an ipv4 address
+				}
+				if strings.Index(ip.String(), "10.") == 0 { //IP should start at 10. within containers
+					return ip.String(), nil
+				}
+
+			}
+		}
+	}
+	return "localhost", err
+}
 
 func ByteToContact(msg []byte) []Contact {
 	s := string(msg)

--- a/util.go
+++ b/util.go
@@ -37,9 +37,8 @@ func Eth0IP() (string, error) {
 				if ip == nil {
 					continue // not an ipv4 address
 				}
-				if strings.Index(ip.String(), "10.") == 0 { //IP should start at 10. within containers
-					return ip.String(), nil
-				}
+				return ip.String(), nil
+				
 
 			}
 		}


### PR DESCRIPTION
Now takes 
`-port X
-bootstrapIP b.IP.x.x:port
`
Instead of reading directly from os.Args